### PR TITLE
Underscore suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,3 +87,4 @@
     - dump_xpaths() not supported.
   - FIX: don't return non-list keys when dir() of a list
   - CLEANUP: remove dormant/unsafe regexes
+  - Append an underscore to nodes which match the python reserved keyswords (defined in Types.py)

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # TODO:
 
+- PROXY does not handle leaf-lists well, if the entries are added/removed a length check/get will retrieve stale results.
 - XPATH forming/decoding lazily forms key='value' - we need to be careful about having special characters/single quotes in the value.
   - VoodooNode.get_keys
   - yangvoodoo\_lookahead_for_list_keys

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -105,8 +105,8 @@ RUN \
       mv dist/*.tar.gz /artefacts
 
 # CHANGE VERSION NUMBER HERE
-ENV MY_VERSION=0.5.7
-ENV GIT_BRANCH=devel
+ENV MY_VERSION=0.5.8
+ENV GIT_BRANCH=master
 ENV MY_ARCH=amd64
 
 

--- a/docker/devel/Dockerfile
+++ b/docker/devel/Dockerfile
@@ -51,7 +51,7 @@ RUN \
     echo -n "YangVoodoo:" >>.buildinfo && \
     # git log | head -n 1 >>.buildinfo && \
     # CHANGE VERSION NUMBER HERE
-    echo "0.5.7" >>.buildinfo && \
+    echo "0.5.8" >>.buildinfo && \
     python3 setup.py install
 
 RUN \

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(name='yangvoodoo',
                  # CHANGE VERSION NUMBER HERE
-                 version='0.0.5.7', author='Adam Allen',
+                 version='0.0.5.8', author='Adam Allen',
                  author_email='allena29@users.noreply.github.com',
                  description='Python based access to YANG Datatstores',
                  long_description=long_description,

--- a/test/experimental/test_new.py
+++ b/test/experimental/test_new.py
@@ -1,0 +1,20 @@
+import libyang
+import unittest
+import yangvoodoo
+import yangvoodoo.stublydal
+
+
+"""
+This set of unit tests uses the stub backend datastore, which is not preseeded with
+any data.
+"""
+
+
+class test_new(unittest.TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+        self.stub = yangvoodoo.stublydal.StubLyDataAbstractionLayer()
+        self.subject = yangvoodoo.DataAccess(data_abstraction_layer=self.stub, disable_proxy=True)
+        self.subject.connect('integrationtest')
+        self.root = self.subject.get_node()

--- a/test/unit/test_libyang_scenario.py
+++ b/test/unit/test_libyang_scenario.py
@@ -102,6 +102,8 @@ class test_new_stuff(unittest.TestCase):
         }
 
         expected_xpaths2 = {
+            '/integrationtest:diff': True,
+            '/integrationtest:diff/adds': True,
             '/integrationtest:diff/adds/a-2nd-leaf': 'A second leaf',
             '/integrationtest:diff/adds/a-leaf': 'A Leaf Value',
             "/integrationtest:diff/adds/a-leaf-list[.='A']": 'A',
@@ -114,7 +116,8 @@ class test_new_stuff(unittest.TestCase):
             "/integrationtest:diff/adds/a-list[listkey='KEY3']/listkey": 'KEY3',
             "/integrationtest:diff/adds/a-list[listkey='KEY3']/listnonkey": 'VAL3',
             '/integrationtest:diff/adds/boolean': True,
-            '/integrationtest:diff/adds/empty-leaf': True
+            '/integrationtest:diff/adds/empty-leaf': True,
+            '/integrationtest:diff/adds/presence-container': True
         }
 
         self.assertEqual(xpaths, expected_xpaths)
@@ -123,6 +126,8 @@ class test_new_stuff(unittest.TestCase):
         differ = yangvoodoo.DiffEngine.DiffIterator(xpaths, xpaths2)
 
         expected_diff_results = {
+            '/integrationtest:diff': (None, True, 1),
+            '/integrationtest:diff/adds': (None, True, 1),
             '/integrationtest:diff/adds/a-leaf': (None, 'A Leaf Value', 1),
             '/integrationtest:diff/adds/a-2nd-leaf': (None, 'A second leaf', 1),
             "/integrationtest:diff/adds/a-list[listkey='KEY1']/listkey": (None, 'KEY1', 1),
@@ -136,6 +141,7 @@ class test_new_stuff(unittest.TestCase):
             "/integrationtest:diff/adds/a-leaf-list[.='C']": (None, 'C', 1),
             '/integrationtest:diff/adds/empty-leaf': (None, True, 1),
             '/integrationtest:diff/adds/boolean': (None, True, 1),
+            '/integrationtest:diff/adds/presence-container': (None, True, 1),
             '/integrationtest:simpleleaf': ('NonEmptyDoc', None, 3)
         }
 

--- a/test/unitcore/test_libyang_stub.py
+++ b/test/unitcore/test_libyang_stub.py
@@ -191,3 +191,48 @@ class test_new_stuff(unittest.TestCase):
         subject.connect('integrationtest')
 
         self.assertEqual(stubly, subject.data_abstraction_layer.libyang_data)
+
+    def test_reserved_kewords(self):
+        self.root.morecomplex.python_reserved_keywords.class_ = 'class'
+        self.assertEqual(repr(self.root.morecomplex.python_reserved_keywords.import_),
+                         "VoodooEmpty{/integrationtest:morecomplex/python-reserved-keywords/import} - Does Not Exist")
+        self.root.morecomplex.python_reserved_keywords.import_.create()
+        self.assertEqual(repr(self.root.morecomplex.python_reserved_keywords.import_),
+                         "VoodooEmpty{/integrationtest:morecomplex/python-reserved-keywords/import} - Exists")
+
+        self.assertEqual(len(self.root.morecomplex.python_reserved_keywords.and_), 0)
+        self.root.morecomplex.python_reserved_keywords.and_.create('x', 'y')
+        self.assertEqual(len(self.root.morecomplex.python_reserved_keywords.and_), 1)
+        self.assertEqual(repr(list(self.root.morecomplex.python_reserved_keywords.and_)[0]),
+                         "VoodooListElement{/integrationtest:morecomplex/python-reserved-keywords/and[break='x'][not-break='y']}"
+                         )
+
+        self.root.morecomplex.leaflists.simple.create('a')
+        self.root.morecomplex.leaflists.simple.create('b')
+        self.root.morecomplex.leaflists.simple.create('c')
+        self.assertEqual(len(self.root.morecomplex.leaflists.simple), 3)
+        self.assertEqual(len(self.root.morecomplex.python_reserved_keywords.global_), 0)
+        self.root.morecomplex.python_reserved_keywords.global_.create('x')
+        self.root.morecomplex.python_reserved_keywords.global_.create('y')
+        self.assertEqual(len(self.root.morecomplex.python_reserved_keywords.global_), 2)
+        self.assertEqual(list(self.root.morecomplex.python_reserved_keywords.global_), ['x', 'y'])
+
+        # Assert
+        self.assertEqual(self.root.morecomplex.python_reserved_keywords.class_, 'class')
+
+        expected_result = {
+            '/integrationtest:morecomplex': True,
+            '/integrationtest:morecomplex/python-reserved-keywords': True,
+            '/integrationtest:morecomplex/python-reserved-keywords/class': 'class',
+            '/integrationtest:morecomplex/python-reserved-keywords/import': True,
+            "/integrationtest:morecomplex/python-reserved-keywords/and[break='x'][not-break='y']/break": 'x',
+            "/integrationtest:morecomplex/python-reserved-keywords/and[break='x'][not-break='y']/not-break": 'y',
+            "/integrationtest:morecomplex/python-reserved-keywords/global[.='x']": 'x',
+            "/integrationtest:morecomplex/python-reserved-keywords/global[.='y']": 'y',
+            '/integrationtest:morecomplex/leaflists': True,
+            "/integrationtest:morecomplex/leaflists/simple[.='a']": 'a',
+            "/integrationtest:morecomplex/leaflists/simple[.='b']": 'b',
+            "/integrationtest:morecomplex/leaflists/simple[.='c']": 'c'
+        }
+
+        self.assertEqual(self.subject.dump_xpaths(), expected_result)

--- a/test/unitcore/test_unit_node_based_access.py
+++ b/test/unitcore/test_unit_node_based_access.py
@@ -81,7 +81,7 @@ class test_node_based_access(unittest.TestCase):
         self.assertEqual(repr(morecomplex), "VoodooContainer{/integrationtest:morecomplex}")
 
         expected_children = ['extraboolean', 'extraboolean2', 'extraboolean3', 'inner', 'leaf2', 'leaf3', 'leaf4',
-                             'leaflists', 'nonconfig', 'percentage', 'superstar']
+                             'leaflists', 'nonconfig', 'percentage', 'python_reserved_keywords', 'superstar']
         self.assertEqual(dir(morecomplex), expected_children)
 
         inner = morecomplex.inner.create()

--- a/yang/integrationtest.yang
+++ b/yang/integrationtest.yang
@@ -936,6 +936,26 @@ module integrationtest {
       }
     }
 
+    container python-reserved-keywords {
+      leaf class {
+        type string;
+      }
+      leaf import {
+        type empty;
+      }
+      list and {
+        key "break not-break";
+        leaf break {
+          type string;
+        }
+        leaf not-break {
+          type string;
+        }
+      }
+      leaf-list global {
+        type string;
+      }
+    }
 
     leaf superstar {
       type percentile95th;

--- a/yangvoodoo/Common.py
+++ b/yangvoodoo/Common.py
@@ -404,6 +404,10 @@ class Utils:
             schema_path = "/" + context.module + ":*/*"
         else:
             schema_path = schema_path + "/*"
+
+        if attr[-1] == '_':
+            attr = attr[:-1]
+
         for child in context.schemactx.find_path(schema_path):
             if child.name().replace('-', '_') == attr:
                 return child.name()
@@ -415,6 +419,7 @@ class Utils:
         keys = []
         for k in node_schema.keys():
             keys.append(k.name())
+        keys.sort()
         return keys
 
     # @staticmethod

--- a/yangvoodoo/Types.py
+++ b/yangvoodoo/Types.py
@@ -1,4 +1,5 @@
-
+RESERVED_PYTHON_KEYWORDS = ('import', 'class', 'in', 'and', 'as', 'not', 'from', 'or', 'global', 'pass',
+                            'if', 'return', 'try', 'is', 'break')
 DATA_ABSTRACTION_MAPPING = {
     # These values are now libyang types, instead of sysrepo
     # the node_types' for PRESENCE_CONTAINER and LIST are

--- a/yangvoodoo/VoodooNode.py
+++ b/yangvoodoo/VoodooNode.py
@@ -13,7 +13,8 @@ class Context:
         self.yang_module = module
 
     def _trace(self, vnt, yn, context, p):
-        self.log.trace("%s: %s %s\nschema: %s\ndata: %s\nparent of: %s", vnt, context, yn.libyang_node,  yn.real_schema_path,  yn.real_data_path, p)
+        self.log.trace("%s: %s %s\nschema: %s\ndata: %s\nparent of: %s", vnt, context, yn.libyang_node,
+                       yn.real_schema_path,  yn.real_data_path, p)
 
 
 class Node:
@@ -209,6 +210,8 @@ class Node:
         answer = []
         for child in context.schemactx.find_path(search_path):
             child_name = child.name()
+            if child_name in Types.RESERVED_PYTHON_KEYWORDS:
+                child_name = child_name + '_'
             if '-' in child_name and not no_translations:
                 new_child_name = child_name.replace('-', '_')
                 child_name = new_child_name
@@ -464,14 +467,17 @@ class List(ContainingNode):
         """
         node = self._node
         keys = Common.Utils.get_keys_from_a_node(node)
-        keys.sort()
-        return keys
+        translated_keys = []
+        for k in keys:
+            if k in Types.RESERVED_PYTHON_KEYWORDS:
+                translated_keys.append(k.replace('-', '_') + '_')
+            else:
+                translated_keys.append(k.replace('-', '_'))
+        translated_keys.sort()
+        return translated_keys
 
     def __dir__(self):
-        node = self._node
-        keys = Common.Utils.get_keys_from_a_node(node)
-        keys.sort()
-        return keys
+        return self.keys()
 
     def get(self, *args):
         """

--- a/yangvoodoo/__init__.py
+++ b/yangvoodoo/__init__.py
@@ -31,7 +31,7 @@ class DataAccess:
     """
 
     # CHANGE VERSION NUMBER HERE
-    __version__ = "0.5.7"
+    __version__ = "0.5.8"
 
     def __init__(self, log=None, local_log=False, data_abstraction_layer=None,
                  disable_proxy=False, use_stub=False):


### PR DESCRIPTION
Append an underscore to nodes which match the python reserved keyswords (defined in Types.py)

e.g.
('import', 'class', 'in', 'and', 'as', 'not', 'from', 'or', 'global', 'pass',  'if', 'return', 'try', 'is', 'break')